### PR TITLE
Fix googletest CMakeLists 'master' to 'main' 

### DIFF
--- a/CMakeLists.txt.googletest
+++ b/CMakeLists.txt.googletest
@@ -5,7 +5,7 @@ project(googletest-download NONE)
 include(ExternalProject)
 ExternalProject_Add(googletest
   GIT_REPOSITORY    https://github.com/google/googletest.git
-  GIT_TAG           master
+  GIT_TAG           main
   SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/googletest-src"
   BINARY_DIR        "${CMAKE_CURRENT_BINARY_DIR}/googletest-build"
   CONFIGURE_COMMAND ""


### PR DESCRIPTION
CMake was not working because google test no longer uses master as a branch. This change fixes cmake by switching the git tag (branch)!