### PR TITLE
Change googletest GIT_TAG from master to main

### DIFF
--- a/CMakeLists.txt.googletest
+++ b/CMakeLists.txt.googletest
@@ -5,7 +5,7 @@ project(googletest-download NONE)
 include(ExternalProject)
 ExternalProject_Add(googletest
   GIT_REPOSITORY    https://github.com/google/googletest.git
-  GIT_TAG           master
+  GIT_TAG           main
   SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/googletest-src"
   BINARY_DIR        "${CMAKE_CURRENT_BINARY_DIR}/googletest-build"
   CONFIGURE_COMMAND ""


### PR DESCRIPTION
Since 'master' branch on the 'https://github.com/google/googletest' repo does not exist, CMake was failing to clone the repo using 'CMakeLists.txt.googletest' file.

Changing the GIT_TAG to 'main' solves this problem by correctly referencing the main branch.